### PR TITLE
Added an optional substitution to remove the query string from the url.

### DIFF
--- a/prpm-filter.sh
+++ b/prpm-filter.sh
@@ -73,6 +73,9 @@ gawk -P 'BEGIN {
         # Uncomment to strip path from show filename, if desired
         #gsub(".*/", "", url)
 
+        # Uncomment to strip query string from show filename, if desired
+        #gsub("\\?.*$", "", url)
+
         print url, yyyy"-"mm"-"dd, ip, ua
     }' | sort -u
 #eof


### PR DESCRIPTION
This pull request adds an optional substitution to remove the query string from the URL. Ubuntu Podcast have found that some podcatchers are appending query strings.
